### PR TITLE
feat: disable a/b testing with cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - TypeScript support
 - Cookies to persist variants across users
 - Force a specific variant via url or param. E.g. `url?abs_experiment-x=1` or `this.$abtest('experiment-x', 1);`
+- Disable all a/b tests by cookie (`abs_disabled=1`), which is useful for E2E tests in CI/CD pipelines
 
 ## Dependencies
 

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -37,7 +37,7 @@ export function experimentVariant(
     (exp: Experiment) => exp.name === experimentName
   );
 
-  if (experiment === undefined || Cookies.get(`${COOKIE_PREFIX}_disabled`) == '1') {
+  if (experiment === undefined || Cookies.get(`${COOKIE_PREFIX}_disabled`) === '1') {
     return 0;
   }
 

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -37,7 +37,7 @@ export function experimentVariant(
     (exp: Experiment) => exp.name === experimentName
   );
 
-  if (experiment === undefined) {
+  if (experiment === undefined || Cookies.get(`${COOKIE_PREFIX}_disabled`) == '1') {
     return 0;
   }
 


### PR DESCRIPTION
- Add the possibility to disable the a/b testing with a cookie.
- Useful for E2E testing purposes.